### PR TITLE
remove error log for unsubscribed channel

### DIFF
--- a/lib/mandelbrot-ws-base.js
+++ b/lib/mandelbrot-ws-base.js
@@ -198,7 +198,6 @@ class MandelbrotBase extends EventEmitter {
     }
 
     if (!this._channels['book'][chanId]) {
-      console.error('received invalid channel id from api, id:', chanId)
       return
     }
 


### PR DESCRIPTION
when switching pairs fast, sometimes old messages did still arrive,
producing the log output