### PR TITLE
 state,connections: add new libraries

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 exports.WsBase = require('./lib/mandelbrot-ws-base.js')
+exports.WsBConnect = require('./lib/ws-connect.js')
 
 exports.BaseWallet = require('./lib/base-wallet.js')
 exports.BaseOrderbook = require('./lib/base-ob.js')

--- a/lib/base-wallet.js
+++ b/lib/base-wallet.js
@@ -8,7 +8,7 @@ class Wallet {
   }
 
   parse (d) {
-    const copy = JSON.parse(JSON.stringify(d))
+    const copy = JSON.parse(JSON.stringify(d[2]))
 
     if (this.isSnapshot(copy)) {
       return this.parseSnap(copy)
@@ -35,7 +35,7 @@ class Wallet {
   }
 
   update (u) {
-    const copy = JSON.parse(JSON.stringify(u))
+    const copy = JSON.parse(JSON.stringify(u[2]))
 
     if (this.isSnapshot(copy)) {
       this.setSnapshot(copy)

--- a/lib/mandelbrot-ws-base.js
+++ b/lib/mandelbrot-ws-base.js
@@ -100,11 +100,16 @@ class MandelbrotBase extends EventEmitter {
     this.ws.send(str)
   }
 
+  // deprecated
   subscribeOrderBook (symbol) {
+    this.subscribeOrderbook(symbol)
+  }
+
+  subscribeOrderbook (symbol) {
     return this.subscribe('book', { symbol })
   }
 
-  unSubscribeOrderBook (symbol) {
+  unsubscribeOrderbook (symbol) {
     if (!this._channels['book']) return
     if (!this._channels['book'][symbol]) return
 
@@ -114,7 +119,10 @@ class MandelbrotBase extends EventEmitter {
     delete this._managedState['books'][symbol]
   }
 
+  // deprecated
   unSubscribeOrders () {}
+
+  unsubscribeOrders () {}
 
   subscribe (channel, opts) {
     const msg = {
@@ -248,10 +256,9 @@ class MandelbrotBase extends EventEmitter {
     if (id === 'info-wallet') {
       const wallet = this._managedState.wallet
 
-      const wm = msg[2]
-      if (handler) handler(wallet.parse(wm))
+      if (handler) handler(wallet.parse(msg))
 
-      wallet.update(wm)
+      wallet.update(msg)
       this.internalWalletHandler()
 
       return

--- a/lib/state.js
+++ b/lib/state.js
@@ -1,0 +1,55 @@
+'use strict'
+
+class State {
+  constructor (conf) {
+    this.state = Object.keys(conf.components).reduce((acc, el) => {
+      acc[el] = {}
+
+      return acc
+    }, {})
+
+    this.Components = conf.components
+    this.opts = conf.transform
+  }
+
+  update (descr, data) {
+    const c = this.getComponent(descr)
+
+    c.update(data)
+
+    return [ c.parse(data), c.getState() ]
+  }
+
+  getComponent (descr) {
+    const { component, element = 'default' } = descr
+
+    if (!this.state[component]) {
+      this.state[component] = {}
+    }
+
+    if (!this.state[component][element]) {
+      this.state[component][element] = this._createComponent(component, element)
+    }
+
+    return this.state[component][element]
+  }
+
+  _createComponent (component, element) {
+    const Component = this.Components[component]
+    const opts = this.opts[component.toLowerCase()]
+
+    return new Component(opts)
+  }
+
+  resetComponent (descr) {
+    const { component, element = 'default' } = descr
+
+    if (!this.state[component] || !this.state[component][element]) {
+      return
+    }
+
+    this.state[component][element] = this._createComponent(component, element)
+  }
+}
+
+module.exports = State

--- a/lib/ws-connect.js
+++ b/lib/ws-connect.js
@@ -1,0 +1,76 @@
+'use strict'
+
+const EventEmitter = require('events')
+const WebSocket = require('isomorphic-ws')
+
+class WsConnect extends EventEmitter {
+  constructor (conf) {
+    super()
+
+    this.url = conf.url
+  }
+
+  open () {
+    const ws = this.ws = new WebSocket(this.url)
+
+    ws.onerror = (err) => {
+      this.emit('error', err)
+    }
+
+    ws.onopen = () => {
+      this.connected = true
+      this.emit('open')
+    }
+
+    ws.onclose = () => {
+      this.connected = false
+      this.emit('close')
+    }
+
+    ws.onmessage = (m) => {
+      let msg
+
+      try {
+        msg = JSON.parse(m.data)
+      } catch (e) {
+        const err = new Error('invalid message, see info and msg prop')
+        err.info = e
+        err.msg = m.data
+
+        this.emit('error', err)
+        return
+      }
+
+      this.emit('message', msg)
+    }
+  }
+
+  close () {
+    this.ws.close()
+  }
+
+  send (msg) {
+    const str = JSON.stringify(msg)
+    this.ws.send(str)
+  }
+
+  subscribe (channel, opts) {
+    const msg = {
+      event: 'subscribe',
+      channel: channel
+    }
+
+    this.send(Object.assign(msg, opts))
+  }
+
+  unsubscribe (channel, opts) {
+    const msg = {
+      event: 'unsubscribe',
+      channel: channel
+    }
+
+    this.send(Object.assign(msg, opts))
+  }
+}
+
+module.exports = WsConnect

--- a/lib/ws-msg-handler.js
+++ b/lib/ws-msg-handler.js
@@ -1,0 +1,221 @@
+'use strict'
+
+const EventEmitter = require('events')
+
+class MsgHandler extends EventEmitter {
+  constructor (opts) {
+    super()
+
+    this.conf = opts
+    this._channels = {}
+
+    this._managedState = opts.state
+
+    Object.keys(this.conf.transports).forEach((tn) => {
+      this.conf.transports[tn].on('message', this.handleMessage.bind(this))
+    })
+
+    if (opts.customHandler) {
+      this.customHandler = opts.customHandler
+    }
+
+    this.handlers = {}
+  }
+
+  addCallback (name) {
+    const hook = (filter, handler) => {
+      let mod = 'default'
+
+      if (filter && filter.symbol) {
+        mod = filter.symbol
+      }
+
+      const [handlerNamePlain] = this.getHandlerNames(name, mod)
+      this.handlers[handlerNamePlain] = handler
+    }
+
+    return hook
+  }
+
+  getHandlerNames (name, mod = 'def') {
+    if (/^on/.test(name)) {
+      const plain = name + '#' + mod
+      const managed = name + '#' + mod
+
+      return [plain, managed]
+    }
+
+    const plain = 'on' + name + '#' + mod
+    const managed = 'onManaged' + name + '#' + mod
+    return [plain, managed]
+  }
+
+  isInfoMsg (msg) {
+    return Array.isArray(msg) && (msg[0] === '0' || msg[0] === 0)
+  }
+
+  handleMessage (msg) {
+    if (this.customHandler && this.customHandler(msg)) {
+      return
+    }
+
+    if (msg.event) {
+      this.handleEventMessage(msg)
+      return
+    }
+
+    // main channel
+    if (this.isInfoMsg(msg)) {
+      this.handleInfoMessage(msg)
+      return
+    }
+
+    if (Array.isArray(msg)) {
+      const [ chanId, data ] = msg
+
+      if (data === 'te' || data === 'tu') {
+        this.executeCallbacks('PublicTrades', 'default', { parsed: msg })
+        this.executeCallbacks('PublicTrades', chanId, { parsed: msg })
+        return
+      }
+
+      this.handleOrderbookMessage(chanId, data, msg)
+    }
+  }
+
+  executeCallbacks (component, mod, data) {
+    const [pcb, mcb] = this.getHandlerNames(component, mod)
+
+    if (this.handlers[pcb]) {
+      this.handlers[pcb](data.parsed)
+    }
+
+    if (this.handlers[mcb] && data.state) {
+      this.handlers[mcb](data.state)
+    }
+  }
+
+  handleOrderbookMessage (chanId, data, msg) {
+    // channel == book
+    if (!this._channels['book'][chanId]) {
+      return
+    }
+
+    const { symbol } = this._channels['book'][chanId]
+
+    const [
+      parsed,
+      state
+    ] = this._managedState.update({ component: 'Orderbook', element: symbol }, data)
+
+    this.executeCallbacks('Orderbook', symbol, { parsed, state })
+  }
+
+  handleEventMessage (msg) {
+    const { channel, event, chanId } = msg
+
+    if (event === 'subscribed') {
+      if (!this._channels[channel]) {
+        this._channels[channel] = {}
+      }
+
+      this._channels[channel][chanId] = msg
+    }
+
+    if (event === 'unsubscribed') {
+
+      if (this._channels[channel] && this._channels[channel][chanId]) {
+        delete this._channels[channel][chanId]
+      }
+
+      const component = this.getComponentName(channel, chanId)
+      this._managedState.resetComponent({ component: component, element: chanId })
+    }
+  }
+
+  getComponentName (id) {
+    switch (id) {
+      case 'book':
+        return 'Orderbook'
+
+      case 'reports':
+        return 'PublicTrades'
+
+      case 'wallets':
+      case 'ws':
+      case 'wu':
+        return 'Wallet'
+
+      case 'os':
+      case 'on':
+      case 'ou':
+      case 'oc':
+        return 'Orders'
+
+      case 'tu':
+      case 'te':
+      case 'trades':
+        return 'Trades'
+
+      case 'ps':
+      case 'pn':
+      case 'pu':
+      case 'pc':
+        return 'Positions'
+    }
+  }
+
+  handleOrderState (msg) {
+    const name = 'Orders'
+
+    const [
+      parsed,
+      state
+    ] = this._managedState.update({ component: name, element: 'default' }, msg)
+
+    this.executeCallbacks(name, 'default', { parsed, state })
+
+    // additionally filtered by pair
+    let element
+    if (msg[1] === 'os') {
+      element = msg[2][0][3]
+    } else {
+      element = msg[2][3]
+    }
+
+    const [
+      parsedFiltered,
+      stateFiltered
+    ] = this._managedState.update({ component: name, element }, msg)
+
+    this.executeCallbacks(name, element, { parsed: parsedFiltered, state: stateFiltered })
+  }
+
+  handleInfoMessage (msg) {
+    if (!msg) return
+
+    const [, id] = msg
+    const name = this.getComponentName(id)
+
+    if (!name) return
+
+    if (name === 'Trades') {
+      this.executeCallbacks('PrivateTrades', 'default', { parsed: msg })
+      return
+    }
+
+    if (name === 'Orders') {
+      this.handleOrderState(msg)
+      return
+    }
+
+    const [
+      parsed,
+      state
+    ] = this._managedState.update({ component: name, element: 'default' }, msg)
+
+    this.executeCallbacks(name, 'default', { parsed, state })
+  }
+}
+
+module.exports = MsgHandler

--- a/test/mandelbrot-ws-hive.js
+++ b/test/mandelbrot-ws-hive.js
@@ -3,7 +3,7 @@
 'use strict'
 const assert = require('assert')
 
-const MWsHive = require('../').WsBase
+const Ws = require('../lib/ws-connect')
 const Wock = require('./ws-testhelper.js')
 
 describe('websockets', () => {
@@ -28,7 +28,7 @@ describe('websockets', () => {
     }
 
     const conf = { url: 'ws://localhost:9999' }
-    const ws = new MWsHive(conf)
+    const ws = new Ws(conf)
 
     ws.on('open', () => {
       const msg = {

--- a/test/wallets.js
+++ b/test/wallets.js
@@ -68,34 +68,16 @@ describe('wallet helper', () => {
     ], w.getState())
   })
 
-  it('provides convinience methods that accepts snaps and updates', () => {
-    const w = new Wallet()
-    const snap = [
-      [ 'exchange', 'USD', 98.999, 0, 98.999 ],
-      [ 'exchange', 'ETH', 100, 0, 100 ]
-    ]
-
-    w.update(snap)
-
-    w.update([ 'exchange', 'EOS', 99, 0, null ])
-
-    assert.deepStrictEqual([
-      [ 'exchange', 'USD', 98.999, 0, 98.999 ],
-      [ 'exchange', 'ETH', 100, 0, 100 ],
-      [ 'exchange', 'EOS', 99, 0, 99 ]
-    ], w.getState())
-  })
-
   it('parse() calls do not affect internal state', () => {
     const w = new Wallet()
-    const snap = [
+    const snap = ['0', 'ws', [
       [ 'exchange', 'USD', 97, 0, 97 ],
       [ 'exchange', 'ETH', 100, 0, 100 ]
-    ]
+    ]]
 
     w.update(snap)
-    const u = [ 'exchange', 'ETH', 70, 0, null ]
 
+    const u = ['0', 'wu', [ 'exchange', 'ETH', 70, 0, null ]]
     w.parse(u)
 
     assert.deepStrictEqual([


### PR DESCRIPTION
this PR decouples the state from the websocket connection. this
way it becomes possible to use multiple websocket connections to
connect to different apis.

this PR also cleans up inconsistencies with state handlers, which
are now normalized across the project.

because of the decoupling, the message handlers had to be rewritten.
they are now based on a proxy handler and added dynamically. this
way a lot of repeating boilerplate / copy paste code can get deleted.

next steps:

the old mandelbrot-ws-base is still functional and available, after
the integration in sunbeam is finished, a thin helper wrapper will
replace it.