### PR TITLE
(fix) return on hb add default for book channel

### DIFF
--- a/lib/ws-msg-handler.js
+++ b/lib/ws-msg-handler.js
@@ -73,6 +73,10 @@ class MsgHandler extends EventEmitter {
     if (Array.isArray(msg)) {
       const [chanId, data] = msg
 
+      if (data === 'hb') {
+        return
+      }
+
       if (data === 'te' || data === 'tu') {
         this.executeCallbacks('PublicTrades', 'default', { parsed: msg })
         this.executeCallbacks('PublicTrades', chanId, { parsed: msg })
@@ -97,6 +101,10 @@ class MsgHandler extends EventEmitter {
 
   handleOrderbookMessage (chanId, data, msg) {
     // channel == book
+    if (!this._channels.book) {
+      this._channels.book = {}
+    }
+
     if (!this._channels.book[chanId]) {
       return
     }


### PR DESCRIPTION
If event `hb` is received for bfx api then it will currently be managed by `handleOrderbookMessage` added a return to skip these messages.

`this._channels.book` can be undefined on first call to `handleOrderbookMessage` so check and add default value.